### PR TITLE
Create model for jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,77 @@ version = 3
 [[package]]
 name = "flowcrafter"
 version = "0.0.0"
+dependencies = [
+ "thiserror",
+ "yaml-rust",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/src/flowcrafter/Cargo.toml
+++ b/src/flowcrafter/Cargo.toml
@@ -12,3 +12,5 @@ repository.workspace = true
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+thiserror = "1.0.40"
+yaml-rust = "0.4.5"

--- a/src/flowcrafter/src/error.rs
+++ b/src/flowcrafter/src/error.rs
@@ -1,0 +1,30 @@
+use thiserror::Error;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Error)]
+pub enum Error {
+    #[error("Missing field: {0}")]
+    MissingField(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Error>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Error>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Error>();
+    }
+}

--- a/src/flowcrafter/src/job.rs
+++ b/src/flowcrafter/src/job.rs
@@ -1,0 +1,105 @@
+use std::fmt::Display;
+
+use yaml_rust::Yaml;
+
+use crate::Error;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Job {
+    name: String,
+    template: Yaml,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct JobBuilder {
+    name: Option<String>,
+    template: Option<Yaml>,
+}
+
+impl JobBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub fn template(mut self, template: Yaml) -> Self {
+        self.template = Some(template);
+        self
+    }
+
+    pub fn build(self) -> Result<Job, Error> {
+        let name = self.name.ok_or(Error::MissingField("name".into()))?;
+        let template = self
+            .template
+            .ok_or(Error::MissingField("template".into()))?;
+
+        Ok(Job { name, template })
+    }
+}
+
+impl Display for Job {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl Display for JobBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JobBuilder")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_requires_name() {
+        let build = JobBuilder::new()
+            .template(Yaml::from_str("template"))
+            .build()
+            .unwrap_err();
+
+        assert_eq!(Error::MissingField("name".into()), build);
+    }
+
+    #[test]
+    fn build_requires_template() {
+        let build = JobBuilder::new().name("name").build().unwrap_err();
+
+        assert_eq!(Error::MissingField("template".into()), build);
+    }
+
+    #[test]
+    fn trait_display() {
+        let job = JobBuilder::new()
+            .name("name")
+            .template(Yaml::from_str("template"))
+            .build()
+            .unwrap();
+
+        assert_eq!("name", job.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Job>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Job>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Job>();
+    }
+}

--- a/src/flowcrafter/src/lib.rs
+++ b/src/flowcrafter/src/lib.rs
@@ -1,14 +1,7 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+pub use self::{
+    error::Error,
+    job::{Job, JobBuilder},
+};
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+mod error;
+mod job;


### PR DESCRIPTION
A simple struct has been created that represents a job in a workflow file. Each job has a unique name and a template that contains the job definition.

Jobs can be constructed using a builder pattern. The builder returns a `Result`, and errors out if either `name` or `template` are missing.