### PR TITLE
Create model for workflows

### DIFF
--- a/src/flowcrafter/src/lib.rs
+++ b/src/flowcrafter/src/lib.rs
@@ -1,7 +1,9 @@
 pub use self::{
     error::Error,
     job::{Job, JobBuilder},
+    workflow::{Workflow, WorkflowBuilder},
 };
 
 mod error;
 mod job;
+mod workflow;

--- a/src/flowcrafter/src/workflow.rs
+++ b/src/flowcrafter/src/workflow.rs
@@ -1,0 +1,106 @@
+use std::fmt::{Display, Formatter};
+
+use yaml_rust::Yaml;
+
+use crate::{Error, Job};
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Workflow {
+    name: String,
+    template: Yaml,
+    jobs: Vec<Job>,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct WorkflowBuilder {
+    name: Option<String>,
+    template: Option<Yaml>,
+    jobs: Vec<Job>,
+}
+
+impl WorkflowBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub fn template(mut self, template: Yaml) -> Self {
+        self.template = Some(template);
+        self
+    }
+
+    pub fn job(mut self, job: Job) -> Self {
+        self.jobs.push(job);
+        self
+    }
+
+    pub fn build(self) -> Result<Workflow, Error> {
+        let name = self.name.ok_or(Error::MissingField("name".into()))?;
+        let template = self
+            .template
+            .ok_or(Error::MissingField("template".into()))?;
+        let jobs = self.jobs;
+
+        Ok(Workflow {
+            name,
+            template,
+            jobs,
+        })
+    }
+}
+
+impl Display for Workflow {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl Display for WorkflowBuilder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WorkflowBuilder")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_requires_name() {
+        let builder = WorkflowBuilder::new()
+            .template(Yaml::from_str("template"))
+            .build()
+            .unwrap_err();
+
+        assert_eq!(Error::MissingField("name".into()), builder);
+    }
+
+    #[test]
+    fn build_requires_template() {
+        let builder = WorkflowBuilder::new().name("name").build().unwrap_err();
+
+        assert_eq!(Error::MissingField("template".into()), builder);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Workflow>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Workflow>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Workflow>();
+    }
+}


### PR DESCRIPTION
A simple struct has been created that represents a workflow in a workflow file. Each workflow has a unique name, a template that contains the workflow definition, and a list of jobs that belong to this workflow.

Workflows can be constructed using a builder pattern. The builder returns a `Result`, and errors out if either `name` or `template` are missing. A workflow without a job is theoretically valid and will not result in an error.