### PR TITLE
Simplify error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,16 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
 name = "flowcrafter"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "thiserror",
  "yaml-rust",
 ]

--- a/src/flowcrafter/Cargo.toml
+++ b/src/flowcrafter/Cargo.toml
@@ -12,5 +12,6 @@ repository.workspace = true
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.70"
 thiserror = "1.0.40"
 yaml-rust = "0.4.5"

--- a/src/flowcrafter/src/error.rs
+++ b/src/flowcrafter/src/error.rs
@@ -1,9 +1,9 @@
 use thiserror::Error;
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Error)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[error("Missing field: {0}")]
-    MissingField(String),
+    #[error(transparent)]
+    Unknown(#[from] anyhow::Error),
 }
 
 #[cfg(test)]

--- a/src/flowcrafter/src/job.rs
+++ b/src/flowcrafter/src/job.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::fmt::Display;
 
 use yaml_rust::Yaml;
@@ -32,10 +33,8 @@ impl JobBuilder {
     }
 
     pub fn build(self) -> Result<Job, Error> {
-        let name = self.name.ok_or(Error::MissingField("name".into()))?;
-        let template = self
-            .template
-            .ok_or(Error::MissingField("template".into()))?;
+        let name = self.name.context("missing field 'name'")?;
+        let template = self.template.context("missing field 'template'")?;
 
         Ok(Job { name, template })
     }
@@ -59,19 +58,19 @@ mod tests {
 
     #[test]
     fn build_requires_name() {
-        let build = JobBuilder::new()
+        let error = JobBuilder::new()
             .template(Yaml::from_str("template"))
             .build()
             .unwrap_err();
 
-        assert_eq!(Error::MissingField("name".into()), build);
+        assert_eq!("missing field 'name'", error.to_string());
     }
 
     #[test]
     fn build_requires_template() {
-        let build = JobBuilder::new().name("name").build().unwrap_err();
+        let error = JobBuilder::new().name("name").build().unwrap_err();
 
-        assert_eq!(Error::MissingField("template".into()), build);
+        assert_eq!("missing field 'template'", error.to_string());
     }
 
     #[test]

--- a/src/flowcrafter/src/workflow.rs
+++ b/src/flowcrafter/src/workflow.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::fmt::{Display, Formatter};
 
 use yaml_rust::Yaml;
@@ -39,10 +40,8 @@ impl WorkflowBuilder {
     }
 
     pub fn build(self) -> Result<Workflow, Error> {
-        let name = self.name.ok_or(Error::MissingField("name".into()))?;
-        let template = self
-            .template
-            .ok_or(Error::MissingField("template".into()))?;
+        let name = self.name.context("missing field 'name'")?;
+        let template = self.template.context("missing field 'template'")?;
         let jobs = self.jobs;
 
         Ok(Workflow {
@@ -71,19 +70,19 @@ mod tests {
 
     #[test]
     fn build_requires_name() {
-        let builder = WorkflowBuilder::new()
+        let error = WorkflowBuilder::new()
             .template(Yaml::from_str("template"))
             .build()
             .unwrap_err();
 
-        assert_eq!(Error::MissingField("name".into()), builder);
+        assert_eq!("missing field 'name'", error.to_string());
     }
 
     #[test]
     fn build_requires_template() {
-        let builder = WorkflowBuilder::new().name("name").build().unwrap_err();
+        let error = WorkflowBuilder::new().name("name").build().unwrap_err();
 
-        assert_eq!(Error::MissingField("template".into()), builder);
+        assert_eq!("missing field 'template'", error.to_string());
     }
 
     #[test]


### PR DESCRIPTION
It is too early in the development cycle of the crate to design a robust error type. So we will use a single variant and anyhow for now to generate meaningful error messages. As we start integrating the crate into other applications, we will learn what the needs of consumers are and can refactor the error type.