### PR TITLE
Create crate with command-line tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +196,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +256,21 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -301,6 +398,15 @@ dependencies = [
  "tokio",
  "url",
  "yaml-rust",
+]
+
+[[package]]
+name = "flowcrafter-cli"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "tempfile",
 ]
 
 [[package]]
@@ -653,6 +759,18 @@ name = "ipnet"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "itoa"
@@ -1376,6 +1494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1758,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "src/flowcrafter",
+    "src/flowcrafter-cli",
 ]
 
 [workspace.package]

--- a/src/flowcrafter-cli/Cargo.toml
+++ b/src/flowcrafter-cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "flowcrafter-cli"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "flowcrafter"
+path = "src/main.rs"
+
+# See more keys and their definitions at
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.70"
+clap = { version = "4.2.1", features = ["derive"] }
+tempfile = "3.5.0"
+
+[dev-dependencies]

--- a/src/flowcrafter-cli/src/cli.rs
+++ b/src/flowcrafter-cli/src/cli.rs
@@ -1,0 +1,21 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Clone, Debug, Parser)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
+pub enum Commands {
+    Create {
+        #[arg(short, long)]
+        workflow: String,
+
+        #[arg(short, long)]
+        job: Vec<String>,
+    },
+    Init {
+        repository: String,
+    },
+}

--- a/src/flowcrafter-cli/src/commands/create.rs
+++ b/src/flowcrafter-cli/src/commands/create.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+
+use crate::commands::Command;
+
+pub struct Create {
+    workflow: String,
+    jobs: Vec<String>,
+}
+
+impl Create {
+    pub fn new(workflow: impl Into<String>, jobs: Vec<String>) -> Self {
+        Self {
+            workflow: workflow.into(),
+            jobs,
+        }
+    }
+}
+
+impl Command for Create {
+    fn run(&self) -> Result<()> {
+        println!("Create workflow: {}", self.workflow);
+        println!("Create jobs: {:?}", self.jobs);
+
+        Ok(())
+    }
+}

--- a/src/flowcrafter-cli/src/commands/init.rs
+++ b/src/flowcrafter-cli/src/commands/init.rs
@@ -1,0 +1,180 @@
+use anyhow::{anyhow, Result};
+use std::path::PathBuf;
+
+use crate::commands::Command;
+
+pub struct Init {
+    cwd: PathBuf,
+    repository: String,
+}
+
+impl Init {
+    pub fn new(cwd: PathBuf, repository: impl Into<String>) -> Self {
+        Self {
+            cwd,
+            repository: repository.into(),
+        }
+    }
+
+    fn validate_repository(&self) -> Result<()> {
+        let parts: Vec<&str> = self.repository.split('/').collect();
+
+        if parts.len() != 2 {
+            return Err(anyhow!("repository must have the format owner/name"));
+        }
+
+        Ok(())
+    }
+
+    fn find_project_directory(&self) -> Result<PathBuf> {
+        let mut current_directory = self.cwd.clone();
+
+        loop {
+            let git_directory = current_directory.join(".git");
+
+            if git_directory.exists() {
+                return Ok(current_directory);
+            }
+
+            if !current_directory.pop() {
+                return Err(anyhow!("flowcrafter must be run inside a Git repository"));
+            }
+        }
+    }
+
+    fn find_or_create_directory(&self, directory: PathBuf) -> Result<PathBuf> {
+        if !directory.exists() {
+            std::fs::create_dir_all(directory.clone())?;
+        }
+
+        Ok(directory)
+    }
+
+    fn find_or_create_config(&self, config: PathBuf) -> Result<String> {
+        // TODO: Serialize default configuration and write to file
+        let content = "";
+
+        if !config.exists() {
+            std::fs::write(config, content)?;
+        }
+
+        // TODO: Return instance of `Configuration`
+        Ok(content.to_string())
+    }
+}
+
+impl Command for Init {
+    fn run(&self) -> Result<()> {
+        self.validate_repository()?;
+
+        let project_directory = self.find_project_directory()?;
+        let github_directory = self.find_or_create_directory(project_directory.join(".github"))?;
+
+        let _config = self.find_or_create_config(github_directory.join("flowcrafter.yml"))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::{tempdir, TempDir};
+
+    use super::*;
+
+    fn temp_dir() -> TempDir {
+        // Create project directory
+        let temp_dir = tempdir().unwrap();
+
+        // Create .git directory
+        let git_dir = temp_dir.path().join(".git");
+        std::fs::create_dir(git_dir).unwrap();
+
+        temp_dir
+    }
+
+    #[test]
+    fn run_validates_repository() {
+        let temp_dir = temp_dir();
+        let init = Init::new(temp_dir.path().to_path_buf(), "owner/name");
+
+        assert!(init.run().is_ok());
+    }
+
+    #[test]
+    fn run_errors_if_not_owner_name() {
+        let temp_dir = temp_dir();
+        let init = Init::new(temp_dir.path().to_path_buf(), "repository");
+
+        let error = init.run().unwrap_err();
+
+        assert_eq!(
+            "repository must have the format owner/name",
+            error.to_string()
+        );
+    }
+
+    #[test]
+    fn run_finds_git_repository() {
+        let temp_dir = temp_dir();
+
+        // Create a subdirectory
+        let sub_dir = temp_dir.path().join("sub");
+        std::fs::create_dir(sub_dir.clone()).unwrap();
+
+        let init = Init::new(sub_dir, "owner/name");
+
+        assert!(init.run().is_ok());
+    }
+
+    #[test]
+    fn run_errors_if_not_git_repository() {
+        let temp_dir = tempdir().unwrap();
+
+        let init = Init::new(temp_dir.path().to_path_buf(), "owner/name");
+
+        let error = init.run().unwrap_err();
+
+        assert_eq!(
+            "flowcrafter must be run inside a Git repository",
+            error.to_string()
+        );
+    }
+
+    #[test]
+    fn run_finds_github_directory() {
+        let temp_dir = temp_dir();
+
+        // Create a .github directory
+        let github_dir = temp_dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(github_dir).unwrap();
+
+        let init = Init::new(temp_dir.path().to_path_buf(), "owner/name");
+
+        assert!(init.run().is_ok());
+    }
+
+    #[test]
+    fn run_creates_github_directory() {
+        let temp_dir = temp_dir();
+
+        let init = Init::new(temp_dir.path().to_path_buf(), "owner/name");
+
+        assert!(init.run().is_ok());
+        assert!(temp_dir.path().join(".github").exists());
+    }
+
+    #[test]
+    fn run_writes_flowcrafter_config() {
+        let temp_dir = temp_dir();
+
+        let init = Init::new(temp_dir.path().to_path_buf(), "owner/name");
+
+        assert!(init.run().is_ok());
+
+        let config = temp_dir.path().join(".github").join("flowcrafter.yml");
+        let contents = std::fs::read_to_string(config).unwrap();
+
+        assert!(contents.is_empty());
+    }
+}

--- a/src/flowcrafter-cli/src/commands/mod.rs
+++ b/src/flowcrafter-cli/src/commands/mod.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+
+pub use self::create::Create;
+pub use self::init::Init;
+
+mod create;
+mod init;
+
+pub trait Command {
+    fn run(&self) -> Result<()>;
+}

--- a/src/flowcrafter-cli/src/main.rs
+++ b/src/flowcrafter-cli/src/main.rs
@@ -1,0 +1,20 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::cli::{Cli, Commands};
+use crate::commands::{Command, Create, Init};
+
+mod cli;
+mod commands;
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let cwd = std::env::current_dir().context("failed to detect current directory")?;
+
+    let command: Box<dyn Command> = match &cli.command {
+        Commands::Create { workflow, job } => Box::new(Create::new(workflow, job.to_vec())),
+        Commands::Init { repository } => Box::new(Init::new(cwd, repository)),
+    };
+
+    command.run()
+}


### PR DESCRIPTION
Users can use FlowCrafter through a simple command-line tool. A new crate has been added to the workspace that implements this CLI. A few commands have been prototyped to experiment with the design.