### PR TITLE
Create command to initialize repository

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -1,0 +1,3 @@
+---
+library:
+  repository: jdno/workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "flowcrafter",
+ "serde_yaml",
  "tempfile",
 ]
 

--- a/src/flowcrafter-cli/Cargo.toml
+++ b/src/flowcrafter-cli/Cargo.toml
@@ -18,6 +18,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.70"
 clap = { version = "4.2.1", features = ["derive"] }
+flowcrafter = { path = "../flowcrafter" }
+serde_yaml = "0.9.21"
 tempfile = "3.5.0"
 
 [dev-dependencies]

--- a/src/flowcrafter-cli/src/commands/init.rs
+++ b/src/flowcrafter-cli/src/commands/init.rs
@@ -1,5 +1,8 @@
-use anyhow::{anyhow, Result};
 use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+
+use flowcrafter::{Configuration, LibraryConfiguration};
 
 use crate::commands::Command;
 
@@ -50,16 +53,19 @@ impl Init {
         Ok(directory)
     }
 
-    fn find_or_create_config(&self, config: PathBuf) -> Result<String> {
-        // TODO: Serialize default configuration and write to file
-        let content = "";
+    fn find_or_create_config(&self, config_path: PathBuf) -> Result<Configuration> {
+        let config = Configuration {
+            library: LibraryConfiguration {
+                repository: self.repository.clone(),
+            },
+        };
 
-        if !config.exists() {
-            std::fs::write(config, content)?;
-        }
+        let serialized_config =
+            serde_yaml::to_string(&config).context("failed to serialize default configuration")?;
 
-        // TODO: Return instance of `Configuration`
-        Ok(content.to_string())
+        std::fs::write(config_path, serialized_config)?;
+
+        Ok(config)
     }
 }
 
@@ -175,6 +181,6 @@ mod tests {
         let config = temp_dir.path().join(".github").join("flowcrafter.yml");
         let contents = std::fs::read_to_string(config).unwrap();
 
-        assert!(contents.is_empty());
+        assert!(contents.contains("owner/name"));
     }
 }

--- a/src/flowcrafter/src/configuration.rs
+++ b/src/flowcrafter/src/configuration.rs
@@ -2,12 +2,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct Configuration {
-    library: LibraryConfiguration,
+    pub library: LibraryConfiguration,
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct LibraryConfiguration {
-    repository: String,
+    pub repository: String,
 }
 
 #[cfg(test)]

--- a/src/flowcrafter/src/lib.rs
+++ b/src/flowcrafter/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate core;
 
 pub use self::{
-    configuration::Configuration,
+    configuration::{Configuration, LibraryConfiguration},
     error::Error,
     job::{Job, JobBuilder},
     library::{Library, LibraryBuilder},


### PR DESCRIPTION
The command to initialize a new repository has been finalized. The command takes the name of a GitHub repository as an argument and writes it to a configuration file inside the repositories `.github` directory. Subsequent executions of the flowcrafter CLI can then read this configuration and save the user from providing the settings on each invocation of the command-line tool.