### PR TITLE
Refactor configuration to include owner and name

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -1,3 +1,5 @@
 ---
 library:
-  repository: jdno/workflows
+  repository:
+    owner: jdno
+    name: workflows

--- a/src/flowcrafter-cli/src/commands/init.rs
+++ b/src/flowcrafter-cli/src/commands/init.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, Context, Result};
 
-use flowcrafter::{Configuration, LibraryConfiguration};
+use flowcrafter::{Configuration, LibraryConfiguration, RepositoryConfiguration};
 
 use crate::commands::Command;
 
@@ -54,9 +54,20 @@ impl Init {
     }
 
     fn find_or_create_config(&self, config_path: PathBuf) -> Result<Configuration> {
+        let parts: Vec<String> = self.repository.split('/').map(String::from).collect();
+
         let config = Configuration {
             library: LibraryConfiguration {
-                repository: self.repository.clone(),
+                repository: RepositoryConfiguration {
+                    owner: parts
+                        .get(0)
+                        .context("failed to get owner from repository input")?
+                        .clone(),
+                    name: parts
+                        .get(1)
+                        .context("failed to get name from repository input")?
+                        .clone(),
+                },
             },
         };
 
@@ -181,6 +192,7 @@ mod tests {
         let config = temp_dir.path().join(".github").join("flowcrafter.yml");
         let contents = std::fs::read_to_string(config).unwrap();
 
-        assert!(contents.contains("owner/name"));
+        assert!(contents.contains("owner: owner"));
+        assert!(contents.contains("name: name"));
     }
 }

--- a/src/flowcrafter/src/configuration.rs
+++ b/src/flowcrafter/src/configuration.rs
@@ -7,7 +7,13 @@ pub struct Configuration {
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct LibraryConfiguration {
-    pub repository: String,
+    pub repository: RepositoryConfiguration,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Deserialize, Serialize)]
+pub struct RepositoryConfiguration {
+    pub owner: String,
+    pub name: String,
 }
 
 #[cfg(test)]
@@ -18,15 +24,21 @@ mod tests {
 
     const CONFIG: &str = indoc! {r#"
         library:
-          repository: owner/name
+          repository:
+            owner: owner
+            name: name
     "#};
 
     #[test]
     fn trait_deserialize() {
         let config: Configuration = serde_yaml::from_str(CONFIG).unwrap();
+
         assert_eq!(
             LibraryConfiguration {
-                repository: "owner/name".to_string()
+                repository: RepositoryConfiguration {
+                    owner: "owner".to_string(),
+                    name: "name".to_string(),
+                },
             },
             config.library
         );
@@ -36,7 +48,10 @@ mod tests {
     fn trait_serialize() {
         let config = Configuration {
             library: LibraryConfiguration {
-                repository: "owner/name".to_string(),
+                repository: RepositoryConfiguration {
+                    owner: "owner".to_string(),
+                    name: "name".to_string(),
+                },
             },
         };
 

--- a/src/flowcrafter/src/lib.rs
+++ b/src/flowcrafter/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate core;
 
 pub use self::{
-    configuration::{Configuration, LibraryConfiguration},
+    configuration::{Configuration, LibraryConfiguration, RepositoryConfiguration},
     error::Error,
     job::{Job, JobBuilder},
     library::{Library, LibraryBuilder},

--- a/src/flowcrafter/src/library.rs
+++ b/src/flowcrafter/src/library.rs
@@ -7,7 +7,7 @@ use octocrab::models::repos::Content;
 use octocrab::Octocrab;
 use url::Url;
 
-use crate::{Error, Job, JobBuilder, Workflow, WorkflowBuilder};
+use crate::{Error, Job, JobBuilder, LibraryConfiguration, Workflow, WorkflowBuilder};
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Library {
@@ -142,6 +142,17 @@ impl Default for LibraryBuilder {
 impl Display for Library {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/{}", self.owner, self.name)
+    }
+}
+
+impl TryFrom<&LibraryConfiguration> for Library {
+    type Error = Error;
+
+    fn try_from(config: &LibraryConfiguration) -> Result<Self, Error> {
+        LibraryBuilder::new()
+            .owner(config.repository.owner.clone())
+            .name(config.repository.name.clone())
+            .build()
     }
 }
 


### PR DESCRIPTION
The configuration has been refactored to split out the repository's owner and name. This makes processing the configuration much easier, but is something we might want to revert later when we have more time to implement good error handling and helpful error messages.