### PR TITLE
Serialize and deserialize configuration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,29 @@ jobs:
             echo "$file"
           done
 
+  features:
+    name: Test feature flags
+    runs-on: ubuntu-latest
+
+    needs: detect-changes
+    if: needs.detect-changes.outputs.any_changed == 'true'
+
+    container:
+      image: ghcr.io/jdno/rust:main
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Cache build artifacts
+        uses: swatinem/rust-cache@v2.2.1
+
+      - name: Install cargo-all-features
+        run: cargo install cargo-all-features
+
+      - name: Test all feature flag combinations
+        run: cargo test-all-features
+
   lint:
     name: Lint code
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "liquid",
  "mockito",
  "octocrab",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = "0.1.68"
 base64 = "0.21.0"
 liquid = "0.26.1"
 octocrab = "0.22.0"
+serde = { version = "1.0.163", optional = true, features = ["derive"] }
 thiserror = "1.0.40"
 tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread"] }
 url = "2.3.1"

--- a/src/github/configuration/mod.rs
+++ b/src/github/configuration/mod.rs
@@ -10,6 +10,7 @@ pub use self::builder::GitHubConfigurationBuilder;
 mod builder;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GitHubConfiguration {
     instance: Url,
     owner: Owner,

--- a/src/github/owner.rs
+++ b/src/github/owner.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Owner(String);
 
 impl Owner {

--- a/src/github/repository.rs
+++ b/src/github/repository.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Repository(String);
 
 impl Repository {


### PR DESCRIPTION
The configuration for GitHub can now be serialized and deserialized, which is a requirement for the implementation of FlowCrafter's command-line interface. The feature is put behind a feature flag to allow users to opt-in to the additional dependencies that this feature requires.