### PR TITLE
Create command-line interface with init command

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -1,5 +1,5 @@
----
 library:
-  repository:
+  github:
+    instance: https://api.github.com/
     owner: jdno
-    name: workflows
+    repository: workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +220,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,18 +336,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "flowcrafter"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.0",
+ "clap",
  "indoc",
  "liquid",
  "mockito",
  "octocrab",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "thiserror",
  "tokio",
  "typed-builder",
@@ -438,6 +568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +714,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +804,12 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "liquid"
@@ -876,7 +1050,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1066,6 +1240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1285,20 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "rustls"
@@ -1262,6 +1459,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1595,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1645,6 +1874,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1896,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,32 @@ license = "MIT OR Apache-2.0"
 description = "Create and manage workflows for GitHub Actions"
 repository = "https://github.com/jdno/flowcrafter"
 
+default-run = "flowcrafter"
+
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["cli"]
+cli = [
+    "clap",
+    "serde",
+    "serde_yaml",
+]
+
+[[bin]]
+name = "flowcrafter"
+required-features = ["cli"]
 
 [dependencies]
 anyhow = "1.0.71"
 async-trait = "0.1.68"
 base64 = "0.21.0"
+clap = { version = "4.2.7", optional = true, features = ["derive"] }
 liquid = "0.26.1"
 octocrab = "0.22.0"
 serde = { version = "1.0.163", optional = true, features = ["derive"] }
+serde_yaml = { version = "0.9.21", optional = true }
 thiserror = "1.0.40"
 tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread"] }
 typed-builder = "0.14.0"
@@ -27,3 +43,5 @@ url = "2.3.1"
 indoc = "2.0.1"
 mockito = "1.0.2"
 serde_json = "1.0.96"
+tempfile = "3.5.0"
+serde_yaml = { version = "0.9.21" }

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,0 +1,243 @@
+use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use crate::cli::{CliError, Command, Configuration, LibraryConfiguration};
+use crate::github::{GitHubConfiguration, Owner, Repository};
+use crate::Error;
+
+const REPO_PARSE_ERROR: &str = "repository must be provided in the format 'owner/repository'";
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Init<'a> {
+    repository: &'a str,
+    cwd: &'a Path,
+}
+
+impl<'a> Init<'a> {
+    pub fn new(repository: &'a str, cwd: &'a Path) -> Self {
+        Self { repository, cwd }
+    }
+
+    fn parse_repository(self) -> Result<(Owner, Repository), CliError> {
+        let mut parts = self.repository.split('/');
+
+        let owner = parts
+            .next()
+            .ok_or(CliError::InvalidInput(REPO_PARSE_ERROR))?
+            .into();
+        let repository = parts
+            .next()
+            .ok_or(CliError::InvalidInput(REPO_PARSE_ERROR))?
+            .into();
+
+        Ok((owner, repository))
+    }
+
+    fn find_project_directory(&self) -> Result<PathBuf, CliError> {
+        let mut current_directory = self.cwd.to_path_buf();
+
+        loop {
+            let git_directory = current_directory.join(".git");
+
+            if git_directory.exists() {
+                return Ok(current_directory);
+            }
+
+            if !current_directory.pop() {
+                return Err(CliError::CwdNotGitRepository(
+                    "flowcrafter must be run inside a Git repository",
+                ));
+            }
+        }
+    }
+
+    fn find_or_create_directory(&self, directory: PathBuf) -> Result<PathBuf, CliError> {
+        if !directory.exists() {
+            std::fs::create_dir_all(directory.clone())?;
+        }
+
+        Ok(directory)
+    }
+
+    fn find_or_create_config(
+        &self,
+        config_path: PathBuf,
+        owner: Owner,
+        repository: Repository,
+    ) -> Result<Configuration, CliError> {
+        let config = Configuration::builder()
+            .library(LibraryConfiguration::GitHub(
+                GitHubConfiguration::builder()
+                    .owner(owner)
+                    .repository(repository)
+                    .build(),
+            ))
+            .build();
+
+        let serialized_config = serde_yaml::to_string(&config)?;
+        std::fs::write(config_path, serialized_config)?;
+
+        Ok(config)
+    }
+}
+
+#[async_trait]
+impl Command for Init<'_> {
+    async fn run(&self) -> Result<(), Error> {
+        let (owner, repository) = self.parse_repository()?;
+
+        let project_directory = self.find_project_directory()?;
+        let github_directory = self.find_or_create_directory(project_directory.join(".github"))?;
+        let config_path = github_directory.join("flowcrafter.yml");
+
+        let _config = self.find_or_create_config(config_path, owner, repository)?;
+
+        Ok(())
+    }
+}
+
+impl Display for Init<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "init -r {}", self.repository)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::{tempdir, TempDir};
+
+    use super::*;
+
+    fn temp_dir() -> TempDir {
+        // Create project directory
+        let temp_dir = tempdir().unwrap();
+
+        // Create .git directory
+        let git_dir = temp_dir.path().join(".git");
+        std::fs::create_dir(git_dir).unwrap();
+
+        temp_dir
+    }
+
+    #[test]
+    fn parse_repository() {
+        let command = Init::new("jdno/flowcrafter", Path::new("."));
+
+        let (owner, repository) = command.parse_repository().unwrap();
+
+        assert_eq!(Owner::from("jdno"), owner);
+        assert_eq!(Repository::from("flowcrafter"), repository);
+    }
+
+    #[test]
+    fn parse_repository_with_invalid_format() {
+        let command = Init::new("flowcrafter", Path::new("."));
+
+        let result = command.parse_repository().unwrap_err();
+
+        assert!(result.to_string().contains(REPO_PARSE_ERROR));
+    }
+
+    #[tokio::test]
+    async fn run_parses_repository_input() {
+        let temp_dir = temp_dir();
+        let init = Init::new("jdno/flowcrafter", temp_dir.path());
+
+        assert!(init.run().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_errors_if_repository_not_owner_name() {
+        let temp_dir = temp_dir();
+        let init = Init::new("flowcrafter", temp_dir.path());
+
+        let error = init.run().await.unwrap_err();
+
+        assert_eq!(REPO_PARSE_ERROR, error.to_string());
+    }
+
+    #[tokio::test]
+    async fn run_finds_git_repository() {
+        let temp_dir = temp_dir();
+
+        // Create a subdirectory
+        let sub_dir = temp_dir.path().join("sub");
+        std::fs::create_dir(sub_dir.clone()).unwrap();
+
+        let init = Init::new("jdno/flowcrafter", sub_dir.as_path());
+
+        assert!(init.run().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_errors_if_not_git_repository() {
+        let temp_dir = tempdir().unwrap();
+
+        let init = Init::new("jdno/flowcrafter", temp_dir.path());
+
+        let error = init.run().await.unwrap_err();
+
+        assert_eq!(
+            "flowcrafter must be run inside a Git repository",
+            error.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_finds_github_directory() {
+        let temp_dir = temp_dir();
+
+        // Create a .github directory
+        let github_dir = temp_dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(github_dir).unwrap();
+
+        let init = Init::new("jdno/flowcrafter", temp_dir.path());
+
+        assert!(init.run().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_creates_github_directory() {
+        let temp_dir = temp_dir();
+
+        let init = Init::new("jdno/flowcrafter", temp_dir.path());
+
+        assert!(init.run().await.is_ok());
+        assert!(temp_dir.path().join(".github").exists());
+    }
+
+    #[tokio::test]
+    async fn run_writes_flowcrafter_config() {
+        let temp_dir = temp_dir();
+
+        let init = Init::new("jdno/flowcrafter", temp_dir.path());
+
+        assert!(init.run().await.is_ok());
+
+        let config = temp_dir.path().join(".github").join("flowcrafter.yml");
+        let contents = std::fs::read_to_string(config).unwrap();
+
+        assert!(contents.contains("owner: jdno"));
+        assert!(contents.contains("repository: flowcrafter"));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Init>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Init>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Init>();
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use clap::Subcommand;
+
+use crate::Error;
+
+pub use self::init::Init;
+
+mod init;
+
+#[async_trait]
+pub trait Command {
+    async fn run(&self) -> Result<(), Error>;
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
+pub enum Commands {
+    Init {
+        #[arg(short, long)]
+        repository: String,
+    },
+}
+
+impl Commands {
+    pub async fn execute(command: &Commands, cwd: &Path) -> Result<(), Error> {
+        match command {
+            Commands::Init { repository } => Init::new(repository, cwd).run().await,
+        }
+    }
+}

--- a/src/cli/configuration/library.rs
+++ b/src/cli/configuration/library.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+use crate::github::GitHubConfiguration;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LibraryConfiguration {
+    GitHub(GitHubConfiguration),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LibraryConfiguration>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<LibraryConfiguration>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<LibraryConfiguration>();
+    }
+}

--- a/src/cli/configuration/mod.rs
+++ b/src/cli/configuration/mod.rs
@@ -1,0 +1,109 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+pub use self::library::LibraryConfiguration;
+
+mod library;
+
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, TypedBuilder,
+)]
+pub struct Configuration {
+    #[serde(with = "serde_yaml::with::singleton_map")]
+    library: LibraryConfiguration,
+}
+
+impl Configuration {
+    pub fn library(&self) -> &LibraryConfiguration {
+        &self.library
+    }
+}
+
+impl Display for Configuration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Configuration")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use crate::github::GitHubConfiguration;
+
+    use super::*;
+
+    fn configuration() -> Configuration {
+        Configuration::builder()
+            .library(LibraryConfiguration::GitHub(
+                GitHubConfiguration::builder()
+                    .owner("jdno")
+                    .repository("flowcrafter")
+                    .build(),
+            ))
+            .build()
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn trait_deserialize() {
+        let yaml = indoc!(
+            r#"
+            ---
+            library:
+              github:
+                owner: jdno
+                repository: flowcrafter
+            "#
+        );
+
+        let configuration: Configuration = serde_yaml::from_str(yaml).unwrap();
+
+        assert!(matches!(
+            configuration.library,
+            LibraryConfiguration::GitHub(_)
+        ));
+    }
+
+    #[test]
+    fn trait_display() {
+        assert_eq!("Configuration", configuration().to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Configuration>();
+    }
+
+    #[test]
+    fn trait_serialize() {
+        let yaml = serde_yaml::to_string(&configuration()).unwrap();
+
+        let expected = indoc!(
+            r#"
+                library:
+                  github:
+                    instance: https://api.github.com/
+                    owner: jdno
+                    repository: flowcrafter
+                "#
+        );
+
+        assert_eq!(expected, yaml);
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Configuration>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Configuration>();
+    }
+}

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -1,0 +1,39 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error("{0}")]
+    CwdNotGitRepository(&'static str),
+
+    #[error("{0}")]
+    InvalidInput(&'static str),
+
+    #[error("failed to access the local file system: '{0}'")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Serialization(#[from] serde_yaml::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CliError>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CliError>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<CliError>();
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+
+pub use self::{
+    commands::*,
+    configuration::{Configuration, LibraryConfiguration},
+    error::CliError,
+};
+
+mod commands;
+mod configuration;
+mod error;
+
+#[derive(Clone, Debug, Parser)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+#[cfg(feature = "cli")]
+use crate::cli::CliError;
 use crate::fragment::FragmentError;
 use crate::github::{Owner, Repository};
 
@@ -13,6 +15,10 @@ pub enum Error {
 
     #[error("{0}")]
     GitHub(#[from] octocrab::Error),
+
+    #[cfg(feature = "cli")]
+    #[error("{0}")]
+    Cli(#[from] CliError),
 
     #[error("{0}")]
     InvalidTemplate(String),

--- a/src/github/library.rs
+++ b/src/github/library.rs
@@ -161,8 +161,8 @@ mod tests {
     fn build_config(server_url: &str) -> GitHubConfiguration {
         GitHubConfiguration::builder()
             .instance(server_url.parse().unwrap())
-            .owner("owner".into())
-            .repository("name".into())
+            .owner("owner")
+            .repository("name")
             .build()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 pub use self::{error::*, fragment::*, renderer::*, template::*, workflow::*};
 
+#[cfg(feature = "cli")]
+pub mod cli;
+
 mod error;
 mod fragment;
 pub mod github;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,13 @@
+use anyhow::Context;
+use clap::Parser;
+
+use flowcrafter::cli::{Cli, Commands};
+use flowcrafter::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let cli = Cli::parse();
+    let cwd = std::env::current_dir().context("failed to detect current directory")?;
+
+    Commands::execute(&cli.command, &cwd).await
+}


### PR DESCRIPTION
Work on the command-line interface for FlowCrafter has been started, beginning with a command to initialize a new repository. Running `flowcrafter init` takes a GitHub repository and writes it into a configuration file. Subsequent command invocations will then be run against the configuration file.