### PR TITLE
Pass project to commands

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -2,4 +2,4 @@ library:
   github:
     instance: https://api.github.com/
     owner: jdno
-    repository: workflows
+    repository: flowcrafter

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,8 +1,7 @@
-use std::path::Path;
-
 use async_trait::async_trait;
 use clap::Subcommand;
 
+use crate::cli::project::Project;
 use crate::Error;
 
 pub use self::init::Init;
@@ -23,9 +22,9 @@ pub enum Commands {
 }
 
 impl Commands {
-    pub async fn execute(command: &Commands, cwd: &Path) -> Result<(), Error> {
+    pub async fn execute(command: &Commands, project: &Project) -> Result<(), Error> {
         match command {
-            Commands::Init { repository } => Init::new(repository, cwd).run().await,
+            Commands::Init { repository } => Init::new(project, repository).run().await,
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ pub use self::{
     commands::*,
     configuration::{Configuration, LibraryConfiguration},
     error::CliError,
+    project::Project,
 };
 
 mod commands;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,15 @@
 use anyhow::Context;
 use clap::Parser;
 
-use flowcrafter::cli::{Cli, Commands};
+use flowcrafter::cli::{Cli, Commands, Project};
 use flowcrafter::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     let cli = Cli::parse();
-    let cwd = std::env::current_dir().context("failed to detect current directory")?;
 
-    Commands::execute(&cli.command, &cwd).await
+    let cwd = std::env::current_dir().context("failed to detect current directory")?;
+    let project = Project::find(cwd)?;
+
+    Commands::execute(&cli.command, &project).await
 }


### PR DESCRIPTION
Instead of being passed the current working directory as a path, commands now get a reference to a `Project` struct. This makes it easier to reuse functionality, e.g. to find the root directory of a project.