### PR TITLE
Save and load configuration

### DIFF
--- a/src/cli/configuration/mod.rs
+++ b/src/cli/configuration/mod.rs
@@ -1,11 +1,16 @@
 use std::fmt::{Display, Formatter};
 
+use anyhow::{Context, Error};
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
+
+use crate::cli::project::Project;
 
 pub use self::library::LibraryConfiguration;
 
 mod library;
+
+const CONFIG_FILE_NAME: &str = "flowcrafter.yml";
 
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, TypedBuilder,
@@ -16,6 +21,35 @@ pub struct Configuration {
 }
 
 impl Configuration {
+    pub fn save(&self, project: &Project) -> Result<(), Error> {
+        let github_path = project.path().join(".github");
+        if !github_path.exists() {
+            std::fs::create_dir_all(github_path.clone())
+                .context("failed to create .github directory in project")?;
+        }
+
+        let config_path = github_path.join(CONFIG_FILE_NAME);
+
+        let serialized =
+            serde_yaml::to_string(self).context("failed to serialize configuration to YAML")?;
+
+        std::fs::write(config_path, serialized).context("failed to write configuration to file")?;
+
+        Ok(())
+    }
+
+    pub fn load(project: &Project) -> Result<Self, Error> {
+        let config_path = project.path().join(".github").join(CONFIG_FILE_NAME);
+
+        let serialized =
+            std::fs::read_to_string(config_path).context("failed to read configuration file")?;
+
+        let config =
+            serde_yaml::from_str(&serialized).context("failed to deserialize configuration")?;
+
+        Ok(config)
+    }
+
     pub fn library(&self) -> &LibraryConfiguration {
         &self.library
     }
@@ -30,10 +64,21 @@ impl Display for Configuration {
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use tempfile::{tempdir, TempDir};
 
     use crate::github::GitHubConfiguration;
 
     use super::*;
+
+    const SERIALIZED_CONFIGURATION: &str = indoc!(
+        r#"
+        ---
+        library:
+          github:
+            owner: jdno
+            repository: flowcrafter
+        "#
+    );
 
     fn configuration() -> Configuration {
         Configuration::builder()
@@ -45,6 +90,99 @@ mod tests {
             ))
             .build()
     }
+
+    fn temp_dir() -> TempDir {
+        // Create project directory
+        let temp_dir = tempdir().unwrap();
+
+        // Create .git directory
+        let git_dir = temp_dir.path().join(".git");
+        std::fs::create_dir(git_dir).unwrap();
+
+        // Create .github directory
+        let github_dir = temp_dir.path().join(".github");
+        std::fs::create_dir(github_dir).unwrap();
+
+        temp_dir
+    }
+
+    #[test]
+    fn save_writes_configuration() {
+        let project_directory = temp_dir();
+        let project = Project::at(project_directory.path().into()).unwrap();
+
+        let saved_config = configuration();
+        saved_config.save(&project).unwrap();
+
+        let loaded_config = Configuration::load(&project).unwrap();
+        assert_eq!(saved_config, loaded_config);
+    }
+
+    #[test]
+    fn save_creates_directory_if_not_exists() {
+        // Create project directory
+        let temp_dir = tempdir().unwrap();
+
+        // Create .git directory
+        let git_dir = temp_dir.path().join(".git");
+        std::fs::create_dir(git_dir).unwrap();
+
+        // Create configuration
+        let project = Project::at(temp_dir.path().into()).unwrap();
+        configuration().save(&project).unwrap();
+
+        assert!(project.path().join(".github").exists());
+    }
+
+    #[test]
+    fn save_overwrites_existing_configuration() {
+        let project_directory = temp_dir();
+        let project = Project::at(project_directory.path().into()).unwrap();
+
+        std::fs::write(
+            project.path().join(".github").join(CONFIG_FILE_NAME),
+            "This is not a valid configuation file in YAML format.",
+        )
+        .unwrap();
+
+        let saved_config = configuration();
+        saved_config.save(&project).unwrap();
+
+        let loaded_config = Configuration::load(&project).unwrap();
+        assert_eq!(saved_config, loaded_config);
+    }
+
+    #[test]
+    fn load_returns_configuration() {
+        let project_directory = temp_dir();
+        let project = Project::at(project_directory.path().into()).unwrap();
+
+        std::fs::write(
+            project.path().join(".github").join(CONFIG_FILE_NAME),
+            SERIALIZED_CONFIGURATION,
+        )
+        .unwrap();
+
+        let loaded_config = Configuration::load(&project).unwrap();
+
+        assert!(matches!(
+            loaded_config.library,
+            LibraryConfiguration::GitHub(_)
+        ));
+    }
+
+    #[test]
+    fn load_returns_error_if_file_not_found() {
+        let project_directory = temp_dir();
+        let project = Project::at(project_directory.path().into()).unwrap();
+
+        let error = Configuration::load(&project).unwrap_err();
+
+        assert_eq!("failed to read configuration file", error.to_string());
+    }
+
+    #[test]
+    fn load_returns_error_if_file_not_yaml() {}
 
     #[cfg(feature = "serde")]
     #[test]


### PR DESCRIPTION
The logic to save and load the configuration from its file has been moved from the `init` command into the `Configuration` type. This makes it reusable in another commands as well.