### PR TITLE
Add lifetime to library trait

### DIFF
--- a/src/fragment/library.rs
+++ b/src/fragment/library.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::fragment::Fragment;
 
 #[async_trait]
-pub trait FragmentLibrary {
-    async fn workflow(&self, name: &str) -> Result<Fragment, Error>;
-    async fn job(&self, workflow: &str, name: &str) -> Result<Fragment, Error>;
+pub trait FragmentLibrary<'a> {
+    async fn workflow(&self, name: &'a str) -> Result<Fragment, Error>;
+    async fn job(&self, workflow: &'a str, name: &'a str) -> Result<Fragment, Error>;
 }

--- a/src/github/library.rs
+++ b/src/github/library.rs
@@ -72,13 +72,13 @@ impl<'a> GitHubLibrary<'a> {
 }
 
 #[async_trait]
-impl<'a> FragmentLibrary for GitHubLibrary<'a> {
-    async fn workflow(&self, name: &str) -> Result<Fragment, Error> {
+impl<'a> FragmentLibrary<'a> for GitHubLibrary<'a> {
+    async fn workflow(&self, name: &'a str) -> Result<Fragment, Error> {
         let path = format!("{name}/workflow.yml");
         self.download(name, &path).await
     }
 
-    async fn job(&self, workflow: &str, name: &str) -> Result<Fragment, Error> {
+    async fn job(&self, workflow: &'a str, name: &'a str) -> Result<Fragment, Error> {
         let path = format!("{workflow}/{name}.yml");
         self.download(name, &path).await
     }


### PR DESCRIPTION
Adding a lifetime to the library trait enables implementations of the trait to take only references to the workflow and job names.