### PR TITLE
Don't indent empty lines

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -41,7 +41,11 @@ impl<'a> Renderer<'a> {
         let mut indented = String::new();
 
         for line in content.lines() {
-            indented.push_str(&format!("  {}\n", line));
+            if line.is_empty() {
+                indented.push('\n');
+            } else {
+                indented.push_str(&format!("  {}\n", line));
+            }
         }
 
         indented
@@ -86,6 +90,8 @@ mod tests {
                 r#"
                 first:
                   name: First
+
+                  runs-on: ubuntu-latest
                 "#
             )),
             fragment(indoc!(
@@ -107,6 +113,8 @@ mod tests {
                 jobs:
                   first:
                     name: First
+
+                    runs-on: ubuntu-latest
 
                   second:
                     name: Second


### PR DESCRIPTION
Empty lines in job templates should not be indented. If such a line is detected, it is now skipped.