### PR TITLE
Create a local path library

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use thiserror::Error;
 
 use crate::fragment::FragmentError;
-use crate::github::{Owner, Repository};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -17,8 +16,11 @@ pub enum Error {
     #[error("{0}")]
     InvalidTemplate(String),
 
-    #[error("failed to find '{0}' in repository '{1}/{2}'")]
-    NotFound(String, Owner, Repository),
+    #[error("{0}")]
+    IO(#[from] std::io::Error),
+
+    #[error("failed to find '{0}' in {1}")]
+    NotFound(String, String),
 
     #[error("failed to render workflow: {0}")]
     Render(String),

--- a/src/fragment/library.rs
+++ b/src/fragment/library.rs
@@ -1,10 +1,12 @@
+use std::fmt::Display;
+
 use async_trait::async_trait;
 
 use crate::error::Error;
 use crate::fragment::Fragment;
 
 #[async_trait]
-pub trait FragmentLibrary<'a> {
+pub trait FragmentLibrary<'a>: Display {
     async fn workflow(&self, name: &'a str) -> Result<Fragment, Error>;
     async fn job(&self, workflow: &'a str, name: &'a str) -> Result<Fragment, Error>;
 }

--- a/src/github/library.rs
+++ b/src/github/library.rs
@@ -44,11 +44,11 @@ impl<'a> GitHubLibrary<'a> {
             .send()
             .await?;
 
-        items.items.into_iter().next().ok_or(Error::NotFound(
-            path.into(),
-            self.config.owner().clone(),
-            self.config.repository().clone(),
-        ))
+        items
+            .items
+            .into_iter()
+            .next()
+            .ok_or(Error::NotFound(path.into(), self.to_string()))
     }
 
     fn decode_content(&self, content: Content) -> Result<String, Error> {
@@ -84,7 +84,12 @@ impl<'a> FragmentLibrary<'a> for GitHubLibrary<'a> {
 
 impl Display for GitHubLibrary<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.config.owner(), self.config.repository())
+        write!(
+            f,
+            "repository {}/{}",
+            self.config.owner(),
+            self.config.repository()
+        )
     }
 }
 
@@ -316,7 +321,7 @@ mod tests {
 
         let library = GitHubLibrary::new(&configuration);
 
-        assert_eq!("jdno/flowcrafter", library.to_string());
+        assert_eq!("repository jdno/flowcrafter", library.to_string());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 mod error;
 mod fragment;
 pub mod github;
+pub mod local;
 mod project;
 mod renderer;
 mod template;

--- a/src/local/configuration.rs
+++ b/src/local/configuration.rs
@@ -1,0 +1,63 @@
+use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
+
+use typed_builder::TypedBuilder;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, TypedBuilder)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LocalConfiguration {
+    #[builder(setter(into))]
+    path: PathBuf,
+}
+
+impl LocalConfiguration {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Display for LocalConfiguration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "local: {}", self.path.display())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::*;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn trait_deserialize() {
+        let yaml = indoc!(
+            r#"
+            ---
+            path: .
+            "#
+        );
+
+        let configuration = serde_yaml::from_str::<LocalConfiguration>(yaml).unwrap();
+
+        assert_eq!(".", configuration.path().to_str().unwrap());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LocalConfiguration>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<LocalConfiguration>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<LocalConfiguration>();
+    }
+}

--- a/src/local/library.rs
+++ b/src/local/library.rs
@@ -1,0 +1,156 @@
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use crate::local::LocalConfiguration;
+use crate::{Error, Fragment, FragmentLibrary, Project, Template};
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct LocalLibrary {
+    path: PathBuf,
+}
+
+impl LocalLibrary {
+    pub fn new(project: &Project, config: &LocalConfiguration) -> Self {
+        let path = project.path().join(config.path());
+
+        Self { path }
+    }
+
+    fn read_template(&self, path: &PathBuf) -> Result<Template, Error> {
+        if !path.exists() {
+            return Err(Error::NotFound(
+                path.file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                self.to_string(),
+            ));
+        }
+
+        Ok(std::fs::read_to_string(path)?.into())
+    }
+}
+
+impl Display for LocalLibrary {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "path {}", self.path.display())
+    }
+}
+
+#[async_trait]
+impl<'a> FragmentLibrary<'a> for LocalLibrary {
+    async fn workflow(&self, name: &'a str) -> Result<Fragment, Error> {
+        let path = self.path.join(name).join("workflow.yml");
+        let template = self.read_template(&path)?;
+
+        Ok(Fragment::builder().name(name).template(template).build())
+    }
+
+    async fn job(&self, workflow: &'a str, name: &'a str) -> Result<Fragment, Error> {
+        let path = self.path.join(workflow).join(format!("{name}.yml"));
+        let template = self.read_template(&path)?;
+
+        Ok(Fragment::builder().name(name).template(template).build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::create_dir;
+
+    use crate::TestProject;
+
+    use super::*;
+
+    #[test]
+    fn new_with_absolute_path() {
+        let test_project = TestProject::new().unwrap();
+
+        let library = LocalLibrary::new(
+            test_project.project(),
+            &LocalConfiguration::builder()
+                .path("/owner/repo/path")
+                .build(),
+        );
+
+        let path = PathBuf::from("/owner/repo/path");
+
+        assert_eq!(path, library.path);
+    }
+
+    #[test]
+    fn new_with_relative_path() {
+        let test_project = TestProject::new().unwrap();
+
+        let library = LocalLibrary::new(
+            test_project.project(),
+            &LocalConfiguration::builder()
+                .path("owner/repo/path")
+                .build(),
+        );
+
+        let path = test_project.path().join("owner/repo/path");
+
+        assert_eq!(path, library.path);
+    }
+
+    #[tokio::test]
+    async fn workflow() {
+        let test_project = TestProject::new().unwrap();
+
+        create_dir(test_project.path().join("workflow")).unwrap();
+        std::fs::write(
+            test_project.path().join("workflow/workflow.yml"),
+            "name: workflow",
+        )
+        .unwrap();
+
+        let library = LocalLibrary::new(
+            test_project.project(),
+            &LocalConfiguration::builder().path(".").build(),
+        );
+
+        let workflow = library.workflow("workflow").await.unwrap();
+
+        assert_eq!(workflow.template().get(), "name: workflow");
+    }
+
+    #[tokio::test]
+    async fn workflow_not_found() {
+        let test_project = TestProject::new().unwrap();
+
+        let library = LocalLibrary::new(
+            test_project.project(),
+            &LocalConfiguration::builder().path(".").build(),
+        );
+
+        let error = library.workflow("workflow").await.unwrap_err();
+
+        assert_eq!(
+            format!(
+                "failed to find 'workflow.yml' in path {}/.",
+                test_project.path().display()
+            ),
+            error.to_string()
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        let test_project = TestProject::new().unwrap();
+
+        let library = LocalLibrary::new(
+            test_project.project(),
+            &LocalConfiguration::builder()
+                .path("owner/repo/path")
+                .build(),
+        );
+
+        let path = test_project.path().join("owner/repo/path");
+
+        assert_eq!(library.to_string(), format!("path {}", path.display()));
+    }
+}

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -1,0 +1,4 @@
+pub use self::{configuration::*, library::*};
+
+mod configuration;
+mod library;


### PR DESCRIPTION
A new library has been implemented that looks for fragments in a local path. This makes it easier to iterate on workflows and test them.