### PR TITLE
Skip serializing default GitHub host

### DIFF
--- a/src/cli/configuration/mod.rs
+++ b/src/cli/configuration/mod.rs
@@ -249,7 +249,6 @@ mod tests {
             r#"
             library:
               github:
-                instance: https://api.github.com/
                 owner: jdno
                 repository: flowcrafter
             workflows:


### PR DESCRIPTION
The configuration enables users to set a custom endpoint for GitHub. This can be useful for users of GitHub Enterprise, but is mostly used to mock GitHub in tests.

The setting is now excluded from the rendered configuration if it points to github.com, which cleans up the configuration.