### PR TITLE
Keep track of workflows and jobs

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -1,5 +1,28 @@
+# This file is managed by FlowCrafter. Manual changes will be overwritten
+# the next time you run FlowCrafter.
+---
 library:
   github:
-    instance: https://api.github.com/
     owner: jdno
     repository: workflows
+workflows:
+  - name: github
+    jobs:
+      - sync-labels
+  - name: json
+    jobs:
+      - style
+  - name: markdown
+    jobs:
+      - lint
+      - style
+  - name: rust
+    jobs:
+      - features
+      - lint
+      - style
+      - test
+  - name: yaml
+    jobs:
+      - lint
+      - style

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -24,8 +24,8 @@ jobs:
         uses: tj-actions/changed-files@v40
         with:
           files: |
-            **/*.yml
             **/*.yaml
+            **/*.yml
 
       - name: Print changed files
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ async-trait = "0.1.74"
 base64 = "0.21.5"
 clap = { version = "4.4.11", optional = true, features = ["derive"] }
 octocrab = "0.32.0"
+indoc = "2.0.4"
 serde = { version = "1.0.193", optional = true, features = ["derive"] }
 serde_yaml = { version = "0.9.27", optional = true }
 thiserror = "1.0.50"
@@ -39,7 +40,6 @@ typed-builder = "0.18.0"
 url = "2.5.0"
 
 [dev-dependencies]
-indoc = "2.0.4"
 mockito = "1.2.0"
 serde_json = "1.0.108"
 tempfile = "3.8.1"

--- a/src/cli/configuration/workflow.rs
+++ b/src/cli/configuration/workflow.rs
@@ -17,6 +17,10 @@ impl WorkflowConfiguration {
     pub fn jobs(&self) -> &[String] {
         &self.jobs
     }
+
+    pub fn set_jobs(&mut self, jobs: Vec<String>) {
+        self.jobs = jobs;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
FlowCrafter now keeps track of generated workflows and their respective jobs in its configuration file inside the repository. This is the first step towards a more "hands off" approach, where FlowCrafter is configured once using `flowcrafter init` and `flowcrafter create` commands. This enables us to work on commands like `flowcrafter update`, which will automatically update all workflows to their latest version.