### PR TITLE
Create command to update workflows

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use clap::Subcommand;
 
+use crate::cli::commands::update::Update;
 use crate::Project;
 
 pub use self::create::Create;
@@ -9,6 +10,7 @@ pub use self::init::Init;
 
 mod create;
 mod init;
+mod update;
 
 #[async_trait]
 pub trait Command {
@@ -27,6 +29,7 @@ pub enum Commands {
         #[arg(short, long)]
         repository: String,
     },
+    Update,
 }
 
 impl Commands {
@@ -34,6 +37,7 @@ impl Commands {
         match command {
             Commands::Create { workflow, jobs } => Create::new(project, workflow, jobs).run().await,
             Commands::Init { repository } => Init::new(project, repository).run().await,
+            Commands::Update => Update::new(project).run().await,
         }
     }
 }

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -1,0 +1,52 @@
+use anyhow::Error;
+use async_trait::async_trait;
+
+use crate::cli::{Command, Configuration, Create};
+use crate::Project;
+
+pub struct Update<'a> {
+    project: &'a Project,
+}
+
+impl<'a> Update<'a> {
+    pub fn new(project: &'a Project) -> Self {
+        Self { project }
+    }
+}
+
+#[async_trait]
+impl<'a> Command for Update<'a> {
+    async fn run(&self) -> Result<(), Error> {
+        let configuration = Configuration::load(self.project)?;
+
+        for workflow in configuration.workflows() {
+            let command = Create::new(self.project, workflow.name(), workflow.jobs());
+            command.run().await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Update>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Update>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Update>();
+    }
+}


### PR DESCRIPTION
A new command has been added that automatically updates all previously created workflows. It uses the list of workflows and their respective jobs that is now part of the configuration, and fetches the latest fragment for each.