### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-12-21
+
+### Added
+
+- Build release artifacts for Linux and macOS
+
 ## [0.2.0] - 2023-12-13
 
 ### Added
@@ -24,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initialize FlowCrafter in a GitHub repository
 - Create workflows by combining templates from GitHub
 
-[unreleased]: https://github.com/jdno/flowcrafter/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/jdno/flowcrafter/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jdno/flowcrafter/releases/tag/v0.3.0
 [0.2.0]: https://github.com/jdno/flowcrafter/releases/tag/v0.2.0
 [0.1.0]: https://github.com/jdno/flowcrafter/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "flowcrafter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flowcrafter"
 
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This version does not include any functionl changes to FlowCrafter, but sets up the infrastructure to build and publish pre-built binaries for Linux and macOS.