### PR TITLE
Allow adding artifacts to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
         with:
           tag: ${{ needs.plan.outputs.tag }}
           allowUpdates: true
-          updateOnlyUnreleased: true
+          updateOnlyUnreleased: false
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}


### PR DESCRIPTION
Our release process first creates a new release and tag on GitHub, before the release workflow builds and then uploads the artifacts. This requires the workflow to be able to modify an existing release.